### PR TITLE
Adds support for optional callbacks onRetriableFailure, debugRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2.2.0 &ndash; February 16, 2018
-- :sparkles: Add support for optional arguments `onRetriableFailure` and `debugRequest` for the `habrok.request` method.
+- :sparkles: Add support for optional arguments `onRetry` and `debugRequest` for the `habrok.request` method.
 
 ## 2.1.0 &ndash; September 11, 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.0 &ndash; February 16, 2018
+- :sparkles: Add support for optional arguments `onRetriableFailure` and `debugRequest` for the `habrok.request` method.
 
 ## 2.1.0 &ndash; September 11, 2017
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ habrok.request(req[, options])
 | Property | Type | Description | Default |
 | :------- | :--- | :---------- | :------ |
 | `attempt` | `Number` | Integer indicating current request sequence number | *None* |
+| `onRetriableFailure` | `Function` | A function executed whenever Habrok retries a request. As an argument, it will pass in an object with same properties returned by a `habrok.request`. | *None* |
+| `debugRequest` | `Function` | A function called after making a successful request or after the maximum number of attempts is met.  As an argument, it will pass in an object with the property `attempt`, the number of attempts made.| *None* |
 
 Generally, `attempt` is not needed. The internal retry engine will pass the current attempt count into the next request. Override only as necessary &ndash; e.g. in cases where the retry logic should be bypassed.
 
@@ -199,7 +201,7 @@ habrok.request({
 The [debug](https://www.npmjs.com/package/debug) module is used for runtime logging. Omit the `DEBUG` environment variable to squelch all logging. Set `DEBUG` to the desired level (e.g. `DEBUG=habrok`) to restrict logging to a desired service. Or, use `DEBUG=*` to get all debug output from everywhere, including dependencies.
 
 ```sh
-DEBUG=habrok* node index
+DEBUG=@agilemd/habrok* node index
 ```
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -155,10 +155,37 @@ habrok.request(req[, options])
 | Property | Type | Description | Default |
 | :------- | :--- | :---------- | :------ |
 | `attempt` | `Number` | Integer indicating current request sequence number | *None* |
-| `onRetriableFailure` | `Function` | A function executed whenever Habrok retries a request. As an argument, it will pass in an object with same properties returned by a `habrok.request`. | *None* |
+| `onRetry` | `Function` | A function executed whenever Habrok retries a request. As an argument, it will pass in an object with same properties returned by a `habrok.request`. | *None* |
 | `debugRequest` | `Function` | A function called after making a successful request or after the maximum number of attempts is met.  As an argument, it will pass in an object with the property `attempt`, the number of attempts made.| *None* |
 
 Generally, `attempt` is not needed. The internal retry engine will pass the current attempt count into the next request. Override only as necessary &ndash; e.g. in cases where the retry logic should be bypassed.
+
+
+##### onRetry(statusCode, error)
+**Parameters**
+| Parameter | Type | Description |
+| :-------- | :--- | :---------- |
+| statusCode | `Number` | The [HTTP status code](https://httpstatuses.com/) of the request that necessitated this retry. |
+| error | `Object` | A [boom-js](https://github.com/hapijs/boom) error. |
+
+**Returns**
+*None*
+
+
+##### debugRequest(debugInfo)
+**Parameters**
+| Parameter | Type | Description |
+| :-------- | :--- | :---------- |
+| debugInfo | `Object` | An object containing information about the series of requests.|
+
+**debugInfo**
+| Key | Type | Description |
+| :-------- | :--- | :---------- |
+| `attempts` | `Number` | The total number of http requests made for a `habrok.request`. If retries is set to 0, and this will always be 1.|
+
+**Returns**
+*None*
+
 
 #### Returns
 

--- a/lib/Habrok.js
+++ b/lib/Habrok.js
@@ -78,7 +78,7 @@ Habrok.prototype.request = function request(raw, opts) {
     } else if (errorCode === ECONNRESET || statusCode > 299) {
       if ((!err && self.RETRY_CODES.indexOf(statusCode) === -1) || attempt >= self.RETRIES) {
         debug('fail', req);
-        if (has(options, 'debugRequest')) resolve(options.debugRequest({ attempt }));
+        if (has(options, 'debugRequest')) options.debugRequest({ attempt });
         return reject(err || boom.create(statusCode, null, body));
       }
 

--- a/lib/Habrok.js
+++ b/lib/Habrok.js
@@ -39,7 +39,8 @@ Habrok.prototype.request = function request(raw, opts) {
   debug('prepare', raw, opts);
 
   const options = opts || {};
-
+  const onRetry = has(options, 'onRetry') ? options.onRetry : () => {};
+  const debugRequest = has(options, 'debugRequest') ? options.debugRequest : () => {};
   const attempt = has(options, 'attempt') ? integer(options.attempt, { min: 0 }) : 1;
   const req = Object.assign({}, raw);
   const self = this;
@@ -78,17 +79,17 @@ Habrok.prototype.request = function request(raw, opts) {
     } else if (errorCode === ECONNRESET || statusCode > 299) {
       if ((!err && self.RETRY_CODES.indexOf(statusCode) === -1) || attempt >= self.RETRIES) {
         debug('fail', req);
-        if (has(options, 'debugRequest')) options.debugRequest({ attempt });
+        debugRequest({ attempts: attempt });
+
         return reject(err || boom.create(statusCode, null, body));
       }
 
       return setTimeout(
         () => {
           debug('retry', raw);
-          if (has(options, 'onRetriableFailure')) {
-            const returnedError = err || boom.create(statusCode, null, body);
-            options.onRetriableFailure(returnedError);
-          }
+          const returnedError = err || boom.create(statusCode, null, body);
+          onRetry(statusCode, returnedError);
+
           resolve(self.request(raw, Object.assign({}, options, { attempt: attempt + 1 })));
         },
         integer(

--- a/lib/Habrok.js
+++ b/lib/Habrok.js
@@ -100,6 +100,7 @@ Habrok.prototype.request = function request(raw, opts) {
     }
 
     debug('succees', req);
+    debugRequest({ attempts: attempt });
 
     return resolve({
       statusCode: res.statusCode,

--- a/lib/Habrok.js
+++ b/lib/Habrok.js
@@ -1,7 +1,7 @@
 const cwd = __dirname;
 
 const boom = require('boom');
-const debug = require('debug')('habrok');
+const debug = require('debug')('@agilemd/habrok');
 const has = require('has');
 const path = require('path');
 const requestjs = require('request');
@@ -78,13 +78,17 @@ Habrok.prototype.request = function request(raw, opts) {
     } else if (errorCode === ECONNRESET || statusCode > 299) {
       if ((!err && self.RETRY_CODES.indexOf(statusCode) === -1) || attempt >= self.RETRIES) {
         debug('fail', req);
-
+        if (has(options, 'debugRequest')) resolve(options.debugRequest({ attempt }));
         return reject(err || boom.create(statusCode, null, body));
       }
 
       return setTimeout(
         () => {
           debug('retry', raw);
+          if (has(options, 'onRetriableFailure')) {
+            const returnedError = err || boom.create(statusCode, null, body);
+            options.onRetriableFailure(returnedError);
+          }
           resolve(self.request(raw, Object.assign({}, options, { attempt: attempt + 1 })));
         },
         integer(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "habrok",
+  "name": "@agilemd/habrok",
   "description": "Promises/A+, request-powered, boom-enabled, JSON-first HTTP API client with automatic retry",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "ISC",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agilemd/habrok",
   "description": "Promises/A+, request-powered, boom-enabled, JSON-first HTTP API client with automatic retry",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "ISC",
   "main": "index.js",
   "engines": {

--- a/test/habrok/request.test.js
+++ b/test/habrok/request.test.js
@@ -291,6 +291,21 @@ describe('Habrok#request with a retried HTTP error (429) and max wait', () => {
     });
   });
 
+  it('calls debugRequest when provided with correct parameters', () => {
+    const method = 'GET';
+    const uri = `https://api.viki.ng/longships/${uuid.v4()}`;
+    const debugRequest = sinon.stub();
+
+    return habrok.request({ method, uri }, { debugRequest })
+    .then(() => { throw new Error('fail test'); })
+    .catch(() => {
+      expect(debugRequest.callCount).to.equal(1);
+
+      const args = debugRequest.getCall(0).args;
+      expect(args[0].attempts).to.equal(habrok.RETRIES);
+    });
+  });
+
   it('rejects within expected elapsed time', () => {
     const method = 'GET';
     const uri = `https://api.viki.ng/longships/${uuid.v4()}`;

--- a/test/habrok/request.test.js
+++ b/test/habrok/request.test.js
@@ -212,6 +212,7 @@ describe('Habrok#request with a retried HTTP error (429)', () => {
       expect(request.callCount).to.equal(habrok.RETRIES);
     });
   });
+
   it('onRetry is called for every retry', () => {
     const method = 'GET';
     const uri = `https://api.viki.ng/longships/${uuid.v4()}`;
@@ -223,7 +224,6 @@ describe('Habrok#request with a retried HTTP error (429)', () => {
       expect(onRetry.callCount).to.equal(habrok.RETRIES - 1);
     });
   });
-
 
   it('rejects with a Boom#tooManyRequests error', () => {
     const method = 'GET';
@@ -560,6 +560,7 @@ describe('Habrok#request with 2 failed requests, then success', () => {
     return habrok.request({ method, uri }, { debugRequest })
     .then(() => {
       expect(debugRequest.callCount).to.equal(1);
+
       const args = debugRequest.getCall(0).args;
       expect(args[0].attempts).to.equal(3);
     });
@@ -580,5 +581,4 @@ describe('Habrok#request with 2 failed requests, then success', () => {
       expect(secondCallArgs[0]).to.equal(secondErrorResponse.statusCode);
     });
   });
-
 });

--- a/test/habrok/request.test.js
+++ b/test/habrok/request.test.js
@@ -515,7 +515,7 @@ describe('Habrok#request with request.js error', () => {
 describe('Habrok#request with 2 failed requests, then success', () => {
   const body = { x: uuid.v4() };
   const firstErrorResponse = { statusCode: 502, headers: { z: uuid.v4() } };
-  const secondErrorResponse = { statusCode: 502, headers: { z: uuid.v4() } };
+  const secondErrorResponse = { statusCode: 503, headers: { z: uuid.v4() } };
   const goodResponse = { statusCode: 200, headers: { z: uuid.v4() } };
 
   let habrok;
@@ -547,33 +547,31 @@ describe('Habrok#request with 2 failed requests, then success', () => {
     const uri = `https://api.viki.ng/longships/${uuid.v4()}`;
 
     return habrok.request({ method, uri })
-    .then(() => { throw new Error('fail test'); })
-    .catch(() => {
+    .then(() => {
       expect(request.callCount).to.equal(3);
     });
   });
+
   it('debugRequest returns 3 attempts', () => {
     const method = 'GET';
     const uri = `https://api.viki.ng/longships/${uuid.v4()}`;
     const debugRequest = sinon.stub();
 
     return habrok.request({ method, uri }, { debugRequest })
-    .then(() => { throw new Error('fail test'); })
-    .catch(() => {
+    .then(() => {
       expect(debugRequest.callCount).to.equal(1);
-
       const args = debugRequest.getCall(0).args;
       expect(args[0].attempts).to.equal(3);
     });
   });
+
   it('onRetry is passed the correct args', () => {
     const method = 'GET';
     const uri = `https://api.viki.ng/longships/${uuid.v4()}`;
     const onRetry = sinon.stub();
 
     return habrok.request({ method, uri }, { onRetry })
-    .then(() => { throw new Error('fail test'); })
-    .catch(() => {
+    .then(() => {
       expect(onRetry.callCount).to.equal(2);
 
       const firstCallArgs = onRetry.getCall(0).args;


### PR DESCRIPTION
Let's try this again...

Adds support for optional callbacks onRetriableFailure, debugRequest
- updates docs
- bumps the minor version
- changes the namespace to `@agilemd/habrok`

@zackliston I'm looking for feedback on everything but in particular:

- method names
- I'm not sure if I'm invoking the callbacks in the correct fashion or if they should be a promise or something?
- the objects I'm passing to the callbacks... do they make sense?
- I didn't write any tests but will attempt to once this stuff looks okay. 
- the optional arguments are passed to the request object. We could instead pass them to the main [configuration object](https://github.com/agilemd/habrok-js#optional-arguments) as optional arguments. 

Sorry about all the questions!